### PR TITLE
Add keyring support to inv-tool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,13 @@ Notes On Installing
     sudo pip install -r requirements.txt
     sudo python setup.py install
 
-``invtool`` requires you to store your ldap username/password in a clear text
-configuration file. ``invtool`` tries to find a configuration file by first
-looking at ``./etc/invtool.conf`` and if it can't find anything there,
-``/etc/invtool.conf``. Here is a quick tip for a non-root install::
+``invtool`` requires you to store your ldap username in a clear text
+configuration file. Your ldap password can be stored either in plaintext in the
+same file or else in the system keyring. In order to use the keyring you need
+`python-keyring <https://pypi.python.org/pypi/keyring>`_.  ``invtool`` tries to
+find a configuration file by first looking at ``./etc/invtool.conf`` and if it
+can't find anything there, ``/etc/invtool.conf``. Here is a quick tip for a
+non-root install::
 
     git clone git@github.com:uberj/inv-tool.git invtool
     cd invtool

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,12 @@ non-root install::
     ln -s ./bin/invtool ./devinvtool
     ./devinvtool status
 
+On this first invocation, if no credentials have been previously set, invtool
+will prompt you for them. If the keyring module is present, your password will
+be stored in the system keyring for later use under the service
+"invtool-ldap". The keyring service name can be changed in the configuration
+file.
+
 RTFM
 ====
 

--- a/etc/invtool.conf-dist
+++ b/etc/invtool.conf-dist
@@ -7,4 +7,4 @@ dev = False
 
 [authorization]
 ldap_username =
-ldap_password =
+keyring = invtool-ldap

--- a/invtool/lib/config.py
+++ b/invtool/lib/config.py
@@ -1,5 +1,6 @@
 import os
 import ConfigParser
+import getpass
 
 API_MAJOR_VERSION = 1
 GLOBAL_CONFIG_FILE = "/etc/invtool.conf"
@@ -19,6 +20,9 @@ else:
 config = ConfigParser.ConfigParser()
 config.read(CONFIG_FILE)
 
+if not config.has_section('authorization'):
+    config.add_section('authorization')
+
 host = config.get('remote', 'host')
 port = config.get('remote', 'port')
 dev = config.get('dev', 'dev')
@@ -29,29 +33,79 @@ REMOTE = "http{0}://{1}{2}".format(
     '' if port == '80' else ':' + port
 )
 
+try:
+    import keyring
+    KEYRING_PRESENT = True
+except ImportError:
+    KEYRING_PRESENT = False
+
 if dev == 'True':
     auth = None
-elif config.has_option('authorization', 'keyring'):
-    try:
-        import keyring
-    except ImportError:
-        raise Exception(
-            "The keyring module could not be imported. "
-            "For keyring support, install the keyring "
-            "module.")
-    auth = (
+    AUTH_TYPE = None
+elif (config.has_option('authorization', 'ldap_password') and
+      config.has_option('authorization', 'keyring')):
+    raise Exception(
+        "ldap_password and keyring are mutually exclusive "
+        "in config file '{0}'".format(CONFIG_FILE)
+    )
+elif (config.has_option('authorization', 'ldap_username') and
+      config.get('authorization', 'ldap_username') != '' and
+      config.has_option('authorization', 'keyring') and
+      config.get('authorization', 'keyring') != '' and
+      KEYRING_PRESENT):
+    # use keyring
+    auth = [
         config.get('authorization', 'ldap_username'),
         keyring.get_password(
             config.get('authorization', 'keyring'),
-            config.get('authorization', 'ldap_username')),
-    )
-    if auth[1] is None:
-        raise Exception(
-            "Can't find ldap password in keyring '{0}'"
-            .format(config.get('authorization', 'keyring'))
+            config.get('authorization', 'ldap_username')
         )
-else:
+    ]
+    if auth[1] is None:
+        keyring.get_keyring()
+        print("Can't retrieve ldap password from keyring '{0}'"
+              .format(config.get('authorization', 'keyring')))
+        auth[1] = getpass.getpass(
+            'ldap username: {0}\npassword: '
+            .format(config.get('authorization', 'ldap_username'))
+        )
+        keyring.set_password(
+            config.get('authorization', 'keyring'),
+            config.get('authorization', 'ldap_username'),
+            auth[1]
+        )
+        print("Saved password to keyring")
+    auth = tuple(auth)
+    AUTH_TYPE = 'keyring'
+elif (config.has_option('authorization', 'ldap_username') and
+      config.has_option('authorization', 'ldap_password')):
+    # use plaintext
     auth = (
         config.get('authorization', 'ldap_username'),
         config.get('authorization', 'ldap_password')
+    )
+    AUTH_TYPE = 'plaintext'
+elif KEYRING_PRESENT:
+    # configure credentials
+    auth = (
+        raw_input('ldap username: '),
+        getpass.getpass('password: ')
+    )
+
+    # store the username and service name
+    config.set('authorization', 'ldap_username', auth[0])
+    if (not config.has_option('authorization', 'keyring') or
+            config.get('authorization', 'keyring') == ''):
+        config.set('authorization', 'keyring', 'invtool-ldap')
+    config.write(open(CONFIG_FILE, 'w'))
+
+    # store the password
+    keyring.set_password(config.get('authorization', 'keyring'), *auth)
+    print("Saved password to keyring")
+    AUTH_TYPE = 'keyring'
+else:
+    raise Exception(
+        "Unable to get or set ldap password."
+        "Install the keyring module or set ldap_password"
+        "in config file '{0}'".format(CONFIG_FILE)
     )

--- a/invtool/lib/config.py
+++ b/invtool/lib/config.py
@@ -31,6 +31,25 @@ REMOTE = "http{0}://{1}{2}".format(
 
 if dev == 'True':
     auth = None
+elif config.has_option('authorization', 'keyring'):
+    try:
+        import keyring
+    except ImportError:
+        raise Exception(
+            "The keyring module could not be imported. "
+            "For keyring support, install the keyring "
+            "module.")
+    auth = (
+        config.get('authorization', 'ldap_username'),
+        keyring.get_password(
+            config.get('authorization', 'keyring'),
+            config.get('authorization', 'ldap_username')),
+    )
+    if auth[1] is None:
+        raise Exception(
+            "Can't find ldap password in keyring '{0}'"
+            .format(config.get('authorization', 'keyring'))
+        )
 else:
     auth = (
         config.get('authorization', 'ldap_username'),

--- a/invtool/status_dispatch.py
+++ b/invtool/status_dispatch.py
@@ -25,7 +25,7 @@ class StatusDispatch(Dispatch):
         """
         Look at the config module and print out interesting things.
         """
-        # Items of intrest
+        # Items of interest
         items = (
             'API_MAJOR_VERSION',
             'CONFIG_FILE',

--- a/invtool/status_dispatch.py
+++ b/invtool/status_dispatch.py
@@ -31,6 +31,7 @@ class StatusDispatch(Dispatch):
             'CONFIG_FILE',
             'GLOBAL_CONFIG_FILE',
             'LOCAL_CONFIG_FILE',
+            'AUTH_TYPE',
             'REMOTE',
             'dev',
             'host',


### PR DESCRIPTION
It's desirable to avoid storing LDAP credentials in plain text. This patch adds keyring support to inv-tool, akin to boto's, that allows you to store your password in the system keyring. See:

https://pypi.python.org/pypi/keyring

for more about the keyring bindings.

Instead of storing your credentials like this:

```
[authorization]
ldap_username = USERNAME
ldap_password = PASSWORD
```

Do this:

```
[authorization]
ldap_username = USERNAME
keyring = KEYRING_NAME
```

And to add your password to the keyring:

```
$ python
>>> import keyring
>>> keyring.set_password(KEYRING_NAME, USERNAME, PASSWORD)
```

NOTES:

The patch has some documentation change, but doesn't actually say explicitly how to set up the keyring (as this pull request does). The invtool.conf-dist provided looks to be a "fill in these fields" type example configuration file, while this would be of the "do this instead of that" variant. Anyway, docs may need to be updated to make the new functionality clearer.

If you are using Fedora, the python-keyring RPM provided in the standard distribution may be out of date, requiring you to install a newer version via another mechanism.
