### PR TITLE
Improve config file handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,11 @@ or passed on the command line. If you do not want to store your credentials
 on disk at all, you must remove the ldap_username AND ldap_password entries
 from the configuration file.
 
-``invtool`` will look for a configuration file at ``./etc/invtool.conf`` and
-if it can't find anything there, ``/etc/invtool.conf``.
+``invtool`` will read its configuration from
+
+ * ``/etc/invtool.conf``
+ * ``~/.invtool.conf`` and
+ * ``./etc/invtool.conf``
 
 Here is a quick tip for a non-root install::
 

--- a/invtool/lib/config.py
+++ b/invtool/lib/config.py
@@ -3,7 +3,7 @@ import ConfigParser
 import getpass
 
 API_MAJOR_VERSION = 1
-INVTOOL_VERSION = 4.0
+INVTOOL_VERSION = 4.1
 GLOBAL_CONFIG_FILE = "/etc/invtool.conf"
 HOME_CONFIG_FILE = os.path.expanduser("~/.invtool.conf")
 LOCAL_CONFIG_FILE = "./etc/invtool.conf"

--- a/invtool/lib/config.py
+++ b/invtool/lib/config.py
@@ -80,10 +80,10 @@ def _keyring():
                 config.get('authorization', 'keyring') == ''):
             config.set('authorization', 'keyring', 'invtool-ldap')
         try:
-            config.write(open(LOCAL_CONFIG_FILE, 'w'))
-            print("Wrote new configuration to {0}".format(LOCAL_CONFIG_FILE))
+            config.write(open(HOME_CONFIG_FILE, 'w'))
+            print("Wrote new configuration to {0}".format(HOME_CONFIG_FILE))
         except OSError:
-            print("could not write keyring configuration to {0}".format(LOCAL_CONFIG_FILE))
+            print("could not write keyring configuration to {0}".format(HOME_CONFIG_FILE))
 
         # store the password
         keyring.set_password(config.get('authorization', 'keyring'), *auth)

--- a/invtool/lib/config.py
+++ b/invtool/lib/config.py
@@ -79,7 +79,11 @@ def _keyring():
         if (not config.has_option('authorization', 'keyring') or
                 config.get('authorization', 'keyring') == ''):
             config.set('authorization', 'keyring', 'invtool-ldap')
-        config.write(open(CONFIG_FILE, 'w'))
+        try:
+            config.write(open(LOCAL_CONFIG_FILE, 'w'))
+            print("Wrote new configuration to {0}".format(LOCAL_CONFIG_FILE))
+        except OSError:
+            print("could not write keyring configuration to {0}".format(LOCAL_CONFIG_FILE))
 
         # store the password
         keyring.set_password(config.get('authorization', 'keyring'), *auth)

--- a/invtool/lib/config.py
+++ b/invtool/lib/config.py
@@ -5,21 +5,15 @@ import getpass
 API_MAJOR_VERSION = 1
 INVTOOL_VERSION = 4.0
 GLOBAL_CONFIG_FILE = "/etc/invtool.conf"
+HOME_CONFIG_FILE = os.path.expanduser("~/.invtool.conf")
 LOCAL_CONFIG_FILE = "./etc/invtool.conf"
+CONFIG_FILES = [GLOBAL_CONFIG_FILE, HOME_CONFIG_FILE, LOCAL_CONFIG_FILE]
 
-if os.path.isfile(LOCAL_CONFIG_FILE):
-    CONFIG_FILE = LOCAL_CONFIG_FILE
-else:
-    if os.path.isfile(GLOBAL_CONFIG_FILE):
-        CONFIG_FILE = GLOBAL_CONFIG_FILE
-    else:
-        raise Exception(
-            "Can't find global config file '{0}'"
-            .format(GLOBAL_CONFIG_FILE)
-        )
+if not any(os.path.exists(f) for f in CONFIG_FILES):
+    raise Exception("No configuration files (%s) found." % (', '.join(map(repr, CONFIG_FILES)),))
 
 config = ConfigParser.ConfigParser()
-config.read(CONFIG_FILE)
+config.read(CONFIG_FILES)
 
 if not config.has_section('authorization'):
     config.add_section('authorization')
@@ -129,8 +123,7 @@ if dev == 'True':
 elif (config.has_option('authorization', 'ldap_password') and
       config.has_option('authorization', 'keyring')):
     raise Exception(
-        "ldap_password and keyring are mutually exclusive "
-        "in config file '{0}'".format(CONFIG_FILE)
+        "ldap_password and keyring cannot both be set in the configuration"
     )
 
 # Always take keyring first

--- a/invtool/status_dispatch.py
+++ b/invtool/status_dispatch.py
@@ -27,8 +27,8 @@ class StatusDispatch(Dispatch):
         items = (
             'API_MAJOR_VERSION',
             'INVTOOL_VERSION',
-            'CONFIG_FILE',
             'GLOBAL_CONFIG_FILE',
+            'HOME_CONFIG_FILE',
             'LOCAL_CONFIG_FILE',
             'AUTH_TYPE',
             'REMOTE',


### PR DESCRIPTION
Allow ~/.invtool.conf as well, and parse all three config files if they
exist, rather than only using one.  Still fail if none exist.
