### PR TITLE
Display error message on authentication failure

### DIFF
--- a/invtool/dispatch.py
+++ b/invtool/dispatch.py
@@ -69,6 +69,10 @@ class Dispatch(object):
             return 0, self.format_response(
                 nas, resp_msg, "http_status: 200 (Success)"
             )
+        elif resp.status_code == 401:
+            return 1, ["Auth Failure! Check your password, or update "
+                        "your keychain using "
+                        "inv-tool/scripts/reset_keychain.py"]
         else:
             resp_list = []
             resp_list.append("Client didn't understand the response.")


### PR DESCRIPTION
Small patch to display a nice error when the authentication fails and mention the keychain update script, as opposed to returning a HTML blob.
