### PR TITLE
Do not try to install files require root privileges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
 from distutils.core import setup
+from os import getuid
+
+if getuid() == 0:
+    # Require root privileges
+    data_files = [('/etc', ['etc/invtool.conf-dist']),
+                  ('/usr/local/share/man/man1/', ['docs/man1/invtool.1.gz'])]
+else:
+    data_files = None
 
 setup(
     name='invtool',
@@ -14,6 +22,5 @@ setup(
     url='https://github.com/uberj/inv-tool',
     license='LICENSE.txt',
     description='An interface to inventory',
-    data_files=[('/etc', ['etc/invtool.conf-dist']),
-                ('/usr/local/share/man/man1/', ['docs/man1/invtool.1.gz'])]
+    data_files=data_files
 )


### PR DESCRIPTION
If you try to install inv-tool without root privileges (virtualenv) it fails:

running install_data
copying etc/invtool.conf-dist -> /etc
error: /etc/invtool.conf-dist: Permission denied
[1]    24593 exit 1     python ./setup.py install

As a work around we can just skip these files.
