### PR TITLE
Typo fix s/use/usr

### DIFF
--- a/scripts/reset_keychain.py
+++ b/scripts/reset_keychain.py
@@ -1,4 +1,4 @@
-#!/use/bin/env python
+#!/usr/bin/env python
 
 import getpass
 import ConfigParser


### PR DESCRIPTION
Hit this when trying to reset my keychain since I changed the password -

shyam@katniss ~/mozilla/invtool/scripts (master*) $ ./reset_keychain.py
zsh: ./reset_keychain.py: bad interpreter: /use/bin/env: no such file or directory
